### PR TITLE
Duplicate color guess handling

### DIFF
--- a/app/turn.rb
+++ b/app/turn.rb
@@ -4,15 +4,15 @@ class Turn
   end
 
   def guess(colors)
-    result = []
+    result = {}
     colors.each_with_index do |color, idx|
       if passcode[idx] == color
-        result << :exact
+        result[color] = :exact
       elsif passcode.include?(color)
-        result << :partial
+        result[color] ||= :partial
       end
     end
-    result.sort
+    result.values.sort
   end
 
   private

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -91,5 +91,31 @@ RSpec.describe Turn do
         expect(feedback).to match_array [:exact, :partial, :partial, :exact]
       end
     end
+
+    context "duplicate color guesses" do
+      it "returns two :exact, ignoring two partials" do
+        turn = Turn.new(passcode: passcode)
+        feedback = turn.guess(["GREEN", "GREEN", "BLUE", "BLUE"])
+        expect(feedback).to match_array [:exact, :exact]
+      end
+
+      it "returns one :exact, ignoring three partials" do
+        turn = Turn.new(passcode: passcode)
+        feedback = turn.guess(["GREEN", "GREEN", "GREEN", "GREEN"])
+        expect(feedback).to match_array [:exact]
+      end
+
+      it "returns one :partial, ignoring two other partials" do
+        turn = Turn.new(passcode: passcode)
+        feedback = turn.guess(["PURPLE", "RED", "RED", "RED"])
+        expect(feedback).to match_array [:partial]
+      end
+
+      it "returns one :partial, one :exact, ignoring two different partials" do
+        turn = Turn.new(passcode: passcode)
+        feedback = turn.guess(["RED", "BLUE", "RED", "BLUE"])
+        expect(feedback).to match_array [:exact, :partial]
+      end
+    end
   end
 end


### PR DESCRIPTION
From Wikipedia:
If there are duplicate colors in the guess, they cannot all be awarded a key peg unless they correspond to the same number of duplicate colors in the hidden code. For example, if the hidden code is red-red-blue-blue and the player guesses red-red-red-blue, the codemaker will award two colored key pegs for the two correct reds, nothing for the third red as there is not a third red in the code, and a colored key peg for the blue. No indication is given of the fact that the code also includes a second blue.